### PR TITLE
main.sh - documentation/convert to cell, extract.sh - mexdex path update

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -32,6 +32,6 @@ then
     fi
 fi
 
-xvfb-run -a --server-args="-screen 0 1024x768x24" $paraviewPath/pvpython  --mesa-llvm   extract.py  $resultsFile $desiredMetricsFile  $pvOutputDir $outputMetrics $caseNumber $convert2cellData 
+xvfb-run -a --server-args="-screen 0 1024x768x24" $paraviewPath/pvpython  --mesa-llvm   mexdex/extract.py  $resultsFile $desiredMetricsFile  $pvOutputDir $outputMetrics $caseNumber $convert2cellData 
 
 

--- a/main.sh
+++ b/main.sh
@@ -2,6 +2,10 @@
 work_dir=`pwd`
 # Import general bash workflow functions
 # . in bash is nearly the same as "source"
+# This line will work as long as the utils
+# directory is passed as a mapped list of
+# files to the SWIFT app that calls this
+# script.
 . utils/general.sh
 case_number=$1
 metricsfile=$2
@@ -29,4 +33,4 @@ fi
 echo "Running mexdex in docker container"
 run_command="docker run --rm  -i --user root -v `pwd`:/scratch -w /scratch docker.io/parallelworks/paraview:v5_4u_imgmagick_rootUser /bin/bash"
 paraviewPath=/opt/ParaView-5.4.1-Qt5-OpenGL2-MPI-Linux-64bit/bin/
-sudo $run_command mexdex/extract.sh ${paraviewPath} ${inputfile} ${kpifile} ${outdir} ${outdir}/dummy
+sudo $run_command mexdex/extract.sh ${paraviewPath} ${inputfile} ${kpifile} ${outdir} ${outdir}/dummy ${case_number} true


### PR DESCRIPTION
- In extract.sh, I added mexdex/ to the path of the python executable mexdex/extract.py.  This allows for using the __init__.py within the mexdex repo.

- In main.sh, I added a short note to remind the user that if one is going to source utils from elsewhere,  that folder too needs to be included in the mapping sent to the SWIFT app.

- In main.sh, I pass the case_number and convert to cell options to extract.sh -> extract.py.  They are easy to remove, but their presence helps to remind the user that those options are present.