### PR TITLE
Changed postprocess.sh for explicit testing of options.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,10 @@ work_dir=`pwd`
 . utils/general.sh
 case_number=$1
 metricsfile=$2
-check_file_exists ${metricsfile}
+# DO NOT CHECK WHETHER THE METRICS FILE
+# exists or not because it can be generated
+# automatically below.
+#check_file_exists ${metricsfile}
 
 # The input file in this case is the output
 # file of the simulation.
@@ -18,19 +21,85 @@ check_file_exists ${inputfile}
 
 # Output directory for Paraview
 outdir=$4
+
+# File that defines all the values to extract
+# is normally called kpi.json.
 kpifile=$5
 check_file_exists ${kpifile}
 
-# WARNING: Assumes all metrics go to same file!!
-metricsfile_kpi=$(cat ${kpifile} | grep -Po '"resultFile":.*?[^\\]",' | cut -d'"' -f4 | uniq | sed "s/{:d}/${case_number}/g")
-# Check that metrics file specified in kpifile is the same as metricsfile:
-if [ ${metricsfile} != ${metricsfile_kpi} ]; then
-    echo "ERROR: Check resultFile key value in ${kpifile}"
-    exit 1
-fi
+#=======================================
+# OPTIONAL INPUTS
+#
+# $6 = the user can define the location
+#      of the mexdex directory which is
+#      where the metrics extractor and
+#      Design Explorer code resides.
+#      This is the same approach as in
+#      postProcess.sh.
+if [ $# -lt 6 ]
+then
+	mexdexDir="."
+else
+	mexdexDir=$6
+fi 
 
+#================================
+# Check that the name of the metricsfile
+# is listed in the kpi file.  This
+# line will search for any resultFile naming
+# lines in the kpi.json and verify that
+# this name is present in an existing
+# metrics file.  If there is no metrics
+# file listed in the kpi file and if
+# that file is not already present,
+# then everything crashes.
+#
+# WARNING: Assumes all metrics go to same file!!
+# In particular, this check assumes that there
+# is only one file that is specified by the
+# "resultFile" entries in the whole kpi.json.
+# This is extremely limiting.
+#
+# (I don't know if this WARNING is strictly
+# true, but it is correct that there are
+# many assumptions at play here.)  Frankly,
+# I don't see the value of this check and
+# would opt to delete it completely.  It crashes
+# the workflow if a given metrics file does
+# not already exist.  If it were not to exist,
+# it would be created automatically by extract.py
+# (which is wrapped in extract.sh).
+#metricsfile_kpi=$(cat ${kpifile} | grep -Po '"resultFile":.*?[^\\]",' | cut -d'"' -f4 | uniq | sed "s/{:d}/${case_number}/g")
+# Check that metrics file specified in kpifile is the same as metricsfile:
+#if [ ${metricsfile} != ${metricsfile_kpi} ]; then
+#    echo "ERROR: Check resultFile key value in ${kpifile}"
+#    exit 1
+#fi
+
+# Also, as far as I can tell, MEXDEX's extract.py
+# and called subroutines do not provide the functionality
+# as stated in the documentation that the metrics
+# requested will be written to a particular file.
+# Instead, as far as I can tell, MEXDEX simply
+# dumps all metrics to the file name specified here.
+# So, the best possible course of action is to
+# rejig MEXDEX so that it creates output files
+# associated with the kpi fields as is in the docs.
+# The next best course of action would be to specify
+# the output file as given in the kpi.json file.
+# However, this would not deal with a variable-by-variable
+# split of metrics, as implied is possible in
+# MEXDEX.  So, I go the third route which is to
+# manually specify the filename based on the
+# input parameters of this script.
 
 echo "Running mexdex in docker container"
 run_command="docker run --rm  -i --user root -v `pwd`:/scratch -w /scratch docker.io/parallelworks/paraview:v5_4u_imgmagick_rootUser /bin/bash"
 paraviewPath=/opt/ParaView-5.4.1-Qt5-OpenGL2-MPI-Linux-64bit/bin/
-sudo $run_command mexdex/extract.sh ${paraviewPath} ${inputfile} ${kpifile} ${outdir} ${outdir}/dummy ${case_number} true
+
+# Older line where the metrics file definition is
+# replaced with dummy.
+#sudo $run_command $mexdexDir/extract.sh ${paraviewPath} ${inputfile} ${kpifile} ${outdir} ${outdir}/dummy ${case_number} true
+
+# Newer line where metrics file is automatically created.
+sudo $run_command $mexdexDir/extract.sh ${paraviewPath} ${inputfile} ${kpifile} ${outdir} ${metricsfile} ${case_number} true

--- a/paramUtils.py
+++ b/paramUtils.py
@@ -299,7 +299,7 @@ def readOutParamsForCase(paramTable, csvTemplateName, caseNumber, kpihash,
 
     if readMEXCSVFile:
         PVcsvAddress = csvTemplateName.format(caseNumber)
-
+        
     solution_converged = True
     for param in paramTable:
         if param[1] >= 0: # Read the parameters from a Mex (Paraview) .csv file

--- a/postprocess.sh
+++ b/postprocess.sh
@@ -1,35 +1,84 @@
 #!/bin/bash
-
+#=======================================
+# This script will create the .html and
+# .csv files read by Design Explorer to
+# display the results of a parameter sweep.
+#
+# The .html file is basically a wrapper
+# for launching Design Explorer.  The
+# .csv file lists parameter values and
+# names associated with the parameter
+# sweep (i.e. the metadata) necessary
+# for graphical display.
+#
+# A previous version treated $7, $8,
+# and $9 as a series of optional inputs,
+# but here I require them as it appears
+# they are necessary.
+#=======================================
+# BASIC INPUTS
+#
+# $1 = the name of the OUTPUT .csv file
+# $2 = the name of the OUTPUT .html file
+# $3 = the user's working directory on
+#      the PW system, which is then used
+#      to build paths in the .html file.
+# $4 = an explicit list of cases in the
+#      parameter sweep with each line
+#      being a list of param_name,param_value,...
+# $5 = the kpi.json file that defines what
+#      metrics and images are made by
+#      the metrics extrator (MEX).
+#=======================================
 outcsv=$1
 outhtml=$2
 rpath=$3
 caseslistFile=$4
 metrics_json=$5
 
-if [ $# -lt 6 ]
-then
-	mexdexDir="."
-else
-	mexdexDir=$6
-fi 
+#=======================================
+# MEXDEX CODE PATH
+#
+# $6 = the user can define the location
+#      of the mexdex directory which is
+#      where the metrics extractor and
+#      Design Explorer code resides.
+mexdexDir=$6
 
-# For cases were png directory and case directory roots are not specified in the kpi.json file:
-setRootDir=false
-if [ $# -eq 9 ]
-then
-	pngOutDirRoot=$7
-	caseDirRoot=$8   
-	outputsList4DE=$9
-	setRootDir=true
-fi
+#======================================
+# PATHS FOR DATA TO DISPLAY
+#
+# An integer, associated with the
+# run count, is added to the end of
+# the pngOutDirRoot ($7)
+# and to caseDirRoot ($8) but not to
+# outputsList4DE ($9).
+pngOutDirRoot=$7
+caseDirRoot=$8
+metricsFileName=$9
 
+# Frankly, I have no evidence that the
+# path specified in the .json file actually
+# makes its way into MEXDEX - it appears
+# NOT to, so this option is actually REQUIRED
+# if you have output in results/case_{:d}.
+# This needs to be tracked down, documented,
+# and cleaned up.  I also cannot find any
+# evidence that outputsList4DE is used by
+# MEXDEX.
+
+#=======================================
+# I don't know what this means yet.
 colorby="stl"
 
+# Print out all the options for running
+# this script for debugging.
 echo $@
 
-#
-# Set the base directory and design explorer base directories
-#
+#=======================================
+# Set the base directory and design explorer
+# base directories
+#=======================================
 if [[ "$rpath" == *"/efs/job_working_directory"* ]];then
 	basedir="$(echo /download$rpath | sed "s|/efs/job_working_directory||g" )"
 	DEbase="/preview"  
@@ -38,27 +87,20 @@ else
 	DEbase="/preview"  
 fi 
 
-#
+#=======================================
 # Generate the design explorer csv file:
-#
-if [ "$setRootDir" = true ] ; then
-	# If the root directories are provided as input to this script, set them when calling mexdex/writeDesignExplorerCsv.py 
-	# Works with both python2 and python3 
-	python   $mexdexDir/writeDesignExplorerCsv.py \
-		--casesList_paramValueDelimiter "=" \
-		--imagesDirectory $pngOutDirRoot{:d} \
-		--includeOutputParamsFile $outputsList4DE \
-		--MECsvPathTemplate  $caseDirRoot{:d}/metrics.csv \
-		$caseslistFile $metrics_json $basedir $outcsv
-else
-	# Works with both python2 and python3 
-	python  $mexdexDir/writeDesignExplorerCsv.py \
-		$caseslistFile $metrics_json $basedir/ $outcsv
-fi
+#=======================================
 
-#
+# Works with both python2 and python3 
+python   $mexdexDir/writeDesignExplorerCsv.py \
+	 --casesList_paramValueDelimiter "," \
+	 --imagesDirectory $pngOutDirRoot{:d} \
+	 --MEXCsvPathTemplate  $caseDirRoot{:d}/$metricsFileName \
+	 $caseslistFile $metrics_json $basedir/ $outcsv
+
+#========================================
 # Generate the design explorer html file:
-#
+#========================================
 baseurl="$DEbase/DesignExplorer/index.html?datafile=$basedir/$outcsv&colorby=$colorby"
 echo '<html style="overflow-y:hidden;background:white"><a style="font-family:sans-serif;z-index:1000;position:absolute;top:15px;right:0px;margin-right:20px;font-style:italic;font-size:10px" href="'$baseurl'" target="_blank">Open in New Window</a><iframe width="100%" height="100%" src="'$baseurl'" frameborder="0"></iframe></html>' > $outhtml
 

--- a/writeDesignExplorerCsv.py
+++ b/writeDesignExplorerCsv.py
@@ -2,8 +2,10 @@ import paramUtils
 import argparse
 import metricsJsonUtils
 import os
+import json
 
-# Generate a csv file for Design Explorer (DEX) from the input parameters and output
+# Generate a csv file for Design Explorer (DEX)
+# from the input parameters and output
 # metrics.
 # Example output csv file for Design Explorer
 """
@@ -86,34 +88,54 @@ cases = paramUtils.readParamsFile(caseListFile, paramValDelim=casesListParamValD
 # Correct input variable names: Replace comma's with "_"
 cases = paramUtils.correct_input_variable_names(cases)
 
-# cases = paramUtils.correct_input_var_names(cases)
-print(" Read " + str(len(cases)) + " Cases")
+print("---> Read " + str(len(cases)) + " cases from " + caseListFile)
 
 # Get the list of input parameters from the first case
 inputVarNames = paramUtils.getParamNamesFromCase(cases[0])
 inputVarNames = list(set(inputVarNames)-ignoreSet)
 
+print("---> Found these input variable names: ")
+for varName in inputVarNames:
+    print(varName)
+
 # Add the values of input parameters for each case to caselist
 caselist = paramUtils.writeInputParamVals2caselist(cases, inputVarNames)
 
+print("---> Found these cases: ")
+for case in caselist:
+    print(case)
+
 # Read the kpihash and set the default values for missing fields
+print("---> Reading the kpi.json file...")
 [kpihash, orderPreservedKeys] = metricsJsonUtils.readKPIJsonFile(kpiFile)
+
+print("---> Original input kpi.json:")
+print(json.dumps(kpihash, indent=4))
+
+print("---> Setting missing fields to defaults:")
 
 for kpi in kpihash:
     kpihash[kpi] = metricsJsonUtils.setKPIFieldDefaults(kpihash[kpi], kpi)
-
-# Read the list of desired output metrics
+    
+print(json.dumps(kpihash, indent=4))
+    
+print("---> Reading list of desired output metrics...")
 outParamTable = paramUtils.getOutputParamsFromKPI(kpihash, orderPreservedKeys, ignoreSet)
 
+print("---> Found these output parameters: ")
+print(outParamTable)
 
-# Add an additional parameter for displaying solution convergence
+print("---> Adding additional simulation_completed parameter...")
+# This is for displaying solution convergence
 outParamTable.append(['simulation_completed', -2])
 
 # Read the desired metric from each output file and add them to caselist
+print("---> Reading metrics from output files...")
 caselist = paramUtils.writeOutParamVals2caselist(cases, metricsFilesNameTemplate,
                                                  outParamTable, caselist, kpihash)
 
 # Get the list of desired images
+print("---> Getting images...")
 imgList, imgNames = paramUtils.getOutImgsFromKPI(kpihash, orderPreservedKeys)
 
 caselist = paramUtils.writeImgs2caselist(cases, imgNames, basepath, imagesdir,
@@ -124,3 +146,5 @@ header = paramUtils.generateHeader(inputVarNames, outParamTable, imgList)
 
 # Write the Design Explorer csv file:
 paramUtils.writeDesignExplorerCSVfile(deCSVFile, header, caselist)
+
+print("---> Done writing Design Explorer csv file.")


### PR DESCRIPTION
In this commit, I made the following changes to steamline the process of calling MEXDEX.
1. main.sh, which launches the extraction part of MEXDEX, dumps metrics directly into a user specified file (the file can be automatically created).
2. main.sh and postprocess.sh have command line options for specifying the location of the MEXDEX code and subroutines at $6.  This allows for placing the MEXDEX code anywhere within the workflow file tree.
3. The previous version would explicitly check for the presence of a metrics file.  This is nice, however, it wasn't fully consistent with the idea of having multiple metrics files.  For example, there may be a metrics file created at the app level (i.e. during a run) and a metrics file created by MEXDEX.  Do you check for one or both?  What are the default responses in each case?  So here, I always create a MEXDEX file and MEXDEX will automatically read the app level files specified in kpi.json.
4. postprocess.sh required a bunch of different variables to be present in order to pass them to writeDesignExplorerCSV.py.  I've sidestepped that requirement and now postprocess.sh is simply passes variables directly to the underlying python (pure wrapping, no attempt at changing configuration info within the wrapper).
5. I had a lot of difficulty figuring out what was going on inside writeDesignExplorerCSV.py - not because it's actually doing any calculations but rather because of the very complicated decision tree that sets up how the metrics and images are presented.  I added some comments and print statements so that it is easier to debug.  Ultimately, this needs to be streamlined and documented more.
